### PR TITLE
[plut-4481] add api docs for new cancelAllOrders endpoint

### DIFF
--- a/source/includes/_changelog.md
+++ b/source/includes/_changelog.md
@@ -2,6 +2,9 @@
 
 Recent changes and additions to the Poloniex API.
 
+## 2019-06-04 cancelAllOrders trading method added
+This new API method allows users to cancel all open orders or all open orders by currencyPair. 
+
 ## 2019-05-09 Additional fields to channel 1000 t message
 Channel 1000 `t` message has been appended to include the total `fee` and `date` at the end of the response respectively. 
 

--- a/source/includes/_http-private.md
+++ b/source/includes/_http-private.md
@@ -808,6 +808,40 @@ success | A boolean indication of the success or failure of this operation.
 amount | The remaning unfilled amount that was canceled in this operation.
 message | A human readable description of the result of the action.
 
+## cancelAllOrders
+
+```shell
+# Note: set the nonce to the current milliseconds. For example: date +%s00000
+echo -n "command=cancelAllOrders&nonce=154264078495300" | \
+openssl sha512 -hmac $API_SECRET
+
+curl -X POST \
+     -d "command=cancelAllOrders&nonce=154264078495300" \
+     -H "Key: 7BCLAZQZ-HKLK9K6U-3MP1RNV9-2LS1L33J" \
+     -H "Sign: 2a7849ecf...ae71161c8e9a364e21d9de9" \
+     https://poloniex.com/tradingApi
+```
+
+> Example output:
+
+```json
+[2345678, 2345679]
+```
+
+Cancels all orders you have placed in a given market or all orders if no market is provided. Optional POST parameter is "currencyPair". If successful, the method will return a json array of orderNumbers for the orders that were canceled.
+
+### Input Fields
+
+Field | Description
+------|------------
+currencyPair | The base and quote currency that define this market.
+
+### Output
+
+ | Description
+-|------------
+ | array of orderIds for canceled orders.
+
 ## moveOrder
 
 ```shell

--- a/source/includes/_http-private.md
+++ b/source/includes/_http-private.md
@@ -812,35 +812,46 @@ message | A human readable description of the result of the action.
 
 ```shell
 # Note: set the nonce to the current milliseconds. For example: date +%s00000
-echo -n "command=cancelAllOrders&nonce=154264078495300" | \
+echo -n "command=cancelAllOrders&nonce=1559587794133" | \
 openssl sha512 -hmac $API_SECRET
 
 curl -X POST \
-     -d "command=cancelAllOrders&nonce=154264078495300" \
+     -d "command=cancelAllOrders&nonce=1559587794133" \
      -H "Key: 7BCLAZQZ-HKLK9K6U-3MP1RNV9-2LS1L33J" \
-     -H "Sign: 2a7849ecf...ae71161c8e9a364e21d9de9" \
+     -H "Sign: 2f2caf61...a3bc7818ced466e8f" \
      https://poloniex.com/tradingApi
 ```
 
 > Example output:
 
 ```json
-[2345678, 2345679]
+{
+    "success": 1,
+    "message": "Orders canceled",
+    "orderNumbers": [
+        503749,
+        888321,
+        7315825,
+        7316824
+    ]
+}
 ```
 
-Cancels all orders you have placed in a given market or all orders if no market is provided. Optional POST parameter is "currencyPair". If successful, the method will return a json array of orderNumbers for the orders that were canceled.
+Cancels all open orders in a given market or, if no market is provided, all open orders in all markets. Optional POST parameter is "currencyPair". If successful, the method will return a success of 1 along with a json array of orderNumbers representing the orders that were canceled.
 
 ### Input Fields
 
 Field | Description
 ------|------------
-currencyPair | The base and quote currency that define this market.
+currencyPair | The base and quote currency that define a market.
 
 ### Output
 
- | Description
--|------------
- | array of orderIds for canceled orders.
+Field | Description
+------|------------
+success | A boolean indication of the success or failure of this operation.
+message | A human readable description of the result of the action.
+orderNumbers | array of orderNumbers representing the orders that were canceled.
 
 ## moveOrder
 


### PR DESCRIPTION
Added documentation for new tradeApi endpoint: cancelAllOrders

![image](https://user-images.githubusercontent.com/48770380/58668385-b61e6b00-8306-11e9-9ca2-86791eb4d685.png)
