### PR TITLE
Add toc link to Github API docs repo

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -15,4 +15,7 @@ includes:
   - changelog
 
 search: true
+
+toc_footers:
+ - <a href='https://github.com/poloniex/api-docs'>Check out these docs on Github</a>
 ---


### PR DESCRIPTION
Adds a little link back to this repo

<img width="190" alt="Screen Shot 2019-06-12 at 10 31 41 AM" src="https://user-images.githubusercontent.com/3126690/59359946-4d1ef600-8cfd-11e9-8d0d-f5f427ed5a1a.png">
