### PR TITLE
[PLUT-4490] Update returnTradeHistory public API docs

### DIFF
--- a/source/includes/_changelog.md
+++ b/source/includes/_changelog.md
@@ -2,6 +2,9 @@
 
 Recent changes and additions to the Poloniex API.
 
+## 2019-06-12 Update returnTradeHistory response to reflect new max
+The max number of trades that can be fetched in a single call has been reduced to 1,000.
+
 ## 2019-06-12 Additional fields to channel 1000 o message
 Channel 1000 `o` message has been appended to include the `orderType` field at the end of the response.
 

--- a/source/includes/_http-public.md
+++ b/source/includes/_http-public.md
@@ -195,7 +195,7 @@ curl "https://poloniex.com/public?command=returnTradeHistory&currencyPair=BTC_ET
     total: '0.07601981' } ]
 ```
 
-Returns the past 200 trades for a given market, or up to 50,000 trades between a range specified in UNIX timestamps by the "start" and "end" GET parameters. Fields include:
+Returns the past 200 trades for a given market, or up to 1,000 trades between a range specified in UNIX timestamps by the "start" and "end" GET parameters. Fields include:
 
 Field | Description
 ------|------------


### PR DESCRIPTION
We reduced the number of rows from 50k to 1,000 for performance reasons for the returnTradeHistory API endpoint, so this is to change the API docs too.

<img width="724" alt="Screen Shot 2019-06-12 at 11 17 38 AM" src="https://user-images.githubusercontent.com/1329204/59363989-21533e80-8d04-11e9-8c9b-53b283d37e96.png">

Currently, it says: `Returns the past 200 trades for a given market, or up to 50,000 trades between a range specified in UNIX timestamps by the "start" and "end" GET parameters.`

https://circlepay.atlassian.net/browse/PLUT-4490