### PR TITLE
[PLUT-5549] updates to clientOrderId docs

### DIFF
--- a/source/includes/_changelog.md
+++ b/source/includes/_changelog.md
@@ -2,6 +2,9 @@
 
 Recent changes and additions to the Poloniex API.
 
+## 2019-07-29 Updates to clientOrderId documentation
+State clientOrderId is 64 bit integer, and when live, must be unique per account
+
 ## 2019-07-24 Add clientOrderId to private http methods and websocket messages
 Some endpoints now support using a client specified integer identifier which will be returned in http responses and "o", "t", "n" websocket messages.
 

--- a/source/includes/_http-private.md
+++ b/source/includes/_http-private.md
@@ -1179,7 +1179,7 @@ Field | Description
 orderNumber | The newly created order number.
 resultingTrades | An array of trades immediately filled by this offer, if any.
 message | A human-readable message summarizing the activity.
-clientOrderId | (optional) Client specified integer identifier.
+clientOrderId | (optional) Client specified 64-bit integer identifier, , that must be unique per live order per account.
 
 ## marginSell
 
@@ -1214,7 +1214,7 @@ currencyPair | The base and quote currency that define this market.
 rate | The number of base currency units to purchase one quote currency unit.
 lendingRate | The interest rate you are willing to accept per day. (default is 0.02 which stands for 2% per day)
 amount | The amount of currency to sell in minor currency units.
-clientOrderId | (optional) Integer value used for tracking order across http responses as well as "o", "n" & "t" web socket messages.
+clientOrderId | (optional) 64 bit Integer value used for tracking order across http responses as well as "o", "n" & "t" web socket messages, , that must be unique per live order per account.
 
 ### Output Fields
 
@@ -1223,7 +1223,7 @@ Field | Description
 orderNumber | The newly created order number.
 resultingTrades | An array of trades immediately filled by this offer, if any.
 message | A human-readable message summarizing the activity.
-clientOrderId | (optional) Client specified integer identifier.
+clientOrderId | (optional) 64 bit Client specified integer identifier, that must be unique per live order per account.
 
 ## getMarginPosition
 


### PR DESCRIPTION
Specify that clientOrderID is a 64 bit integer, and cannot be duplicated per account for live orders.

https://circlepay.atlassian.net/browse/PLUT-5549