### PR TITLE
[TRADE-62] add clarification to doc regarding "startingAmount" interpretation

### DIFF
--- a/source/includes/_changelog.md
+++ b/source/includes/_changelog.md
@@ -2,6 +2,8 @@
 
 Recent changes and additions to the Poloniex API.
 
+## 2020-01-22 Clarifications to returnOpenOrders doc
+
 ## 2020-01-16 ETHBNT Listing
 Listing of Bancor ETH Smart Token Relay (ETHBNT) and the folowing market BTC_ETHBNT.
 

--- a/source/includes/_http-private.md
+++ b/source/includes/_http-private.md
@@ -413,7 +413,8 @@ curl -X POST \
   BTC_SNT: [] }
 ```
 
-Returns your open orders for a given market, specified by the "currencyPair" POST parameter, e.g. "BTC_ETH". Set "currencyPair" to "all" to return open orders for all markets.
+Returns your open orders for a given market, specified by the "currencyPair" POST parameter, e.g. "BTC_ETH". Set "currencyPair" to "all" to return open orders for all markets. 
+Note that the "startingAmount" is not the original amount: it represents the difference of the original amount with any amount that was filled during order placement.
 
 ### Input Fields
 

--- a/source/includes/_http-private.md
+++ b/source/includes/_http-private.md
@@ -414,8 +414,7 @@ curl -X POST \
 ```
 
 Returns your open orders for a given market, specified by the "currencyPair" POST parameter, e.g. "BTC_ETH". Set "currencyPair" to "all" to return open orders for all markets. 
-Note that the "startingAmount" is not the original amount: it represents the difference of the original amount with any amount that was filled during order placement.
-
+Note that the "startingAmount" is not the order placement amount but it is the starting amount of the open order in the book, which excludes any amount that was immediately filled before the order is posted on the book.
 ### Input Fields
 
 Field | Description


### PR DESCRIPTION
"startingAmount" on /returnOpenOrders can be misleading in interpretation - add clarification to what it actually means